### PR TITLE
Conditionally show mcp_session post type UI

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -105,6 +105,7 @@ function register_session_post_type(): void {
 	register_post_type(
 		'mcp_session',
 		[
+			'label'   => __( 'MCP Sessions', 'mcp-wp' ),
 			'public'  => false,
 			'show_ui' => defined( 'WP_DEBUG' ) && !! WP_DEBUG, // For debugging.
 		]

--- a/src/functions.php
+++ b/src/functions.php
@@ -105,7 +105,7 @@ function register_session_post_type(): void {
 	register_post_type(
 		'mcp_session',
 		[
-			'label'   => __( 'MCP Sessions', 'mcp-wp' ),
+			'label'   => __( 'MCP Sessions', 'mcp' ),
 			'public'  => false,
 			'show_ui' => defined( 'WP_DEBUG' ) && !! WP_DEBUG, // For debugging.
 		]

--- a/src/functions.php
+++ b/src/functions.php
@@ -106,7 +106,7 @@ function register_session_post_type(): void {
 		'mcp_session',
 		[
 			'public'  => false,
-			'show_ui' => true, // For debugging.
+			'show_ui' => defined( 'WP_DEBUG' ) && !! WP_DEBUG, // For debugging.
 		]
 	);
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -107,7 +107,7 @@ function register_session_post_type(): void {
 		[
 			'label'   => __( 'MCP Sessions', 'mcp' ),
 			'public'  => false,
-			'show_ui' => defined( 'WP_DEBUG' ) && !! WP_DEBUG, // For debugging.
+			'show_ui' => defined( 'WP_DEBUG' ) && (bool) WP_DEBUG, // For debugging.
 		]
 	);
 }


### PR DESCRIPTION
Set the `mcp_session` label to `MCP Sessions` and conditionally show the `mcp_session` post type UI based on the value of `WP_DEBUG`.

### Changes
- [x] Update `mcp_session` post type label to `MCP Sessions`.
- [x] Show the post type UI when `WP_DEBUG` is true, and hide when it is false.